### PR TITLE
Load urdf with THREE.FileLoader

### DIFF
--- a/javascript/URDFLoader.js
+++ b/javascript/URDFLoader.js
@@ -18,6 +18,11 @@ class URDFLoader {
         return this._textureloader
     }
 
+    static get FileLoader() {
+        this._fileloader = this._fileloader || new THREE.FileLoader()
+        return this._fileloader
+    }
+
     /* Utilities */
     // forEach and filter function wrappers because 
     // HTMLCollection does not the by default
@@ -46,9 +51,7 @@ class URDFLoader {
         loadMeshCb = loadMeshCb || this.defaultMeshLoader
 
         const path = `${pkg}/${urdf}`
-        fetch(path, { credentials:'include' })
-            .then(res => res.text())
-            .then(data => this.loadStr(pkg, data, cb, loadMeshCb))
+        URDFLoader.FileLoader.load(path, data => this.loadStr(pkg, data, cb, loadMeshCb));
     }
 
     static loadStr(pkg, content, cb, loadMeshCb) {


### PR DESCRIPTION
I would suggest to use the `THREE.FileLoader` to load the urdf-file. This allows the possibility to load an URDF from external links (e.g. another Github repo).

For demonstration, I created a modified example `index.html `here: https://github.com/ipa-jfh/urdf-loaders/tree/gh-pages

and tested that the given example still works:

> Running the Example
> Install Node.js and NPM
> Run npm install
> Run npm run server
> Visit localhost:9080/javascript/example/ to view the page