### PR TITLE
Package argument cleanup

### DIFF
--- a/javascript/CHANGELOG.md
+++ b/javascript/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Add "path" variable to parse function signature
 - URDF paths are no longer resolved relative to the package path
+- `parse` function signature changed
+- `parse` returns the robot now
 
 ## [0.3.5] - 2018-08-07
 ### Added

--- a/javascript/CHANGELOG.md
+++ b/javascript/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - URDF paths are no longer resolved relative to the package path
 - `parse` function signature changed
 - `parse` returns the robot now
+- `meshLoadCb` and `fetchOptions` have been moved into an `options` argument object
 
 ## [0.3.5] - 2018-08-07
 ### Added

--- a/javascript/URDFLoader.js
+++ b/javascript/URDFLoader.js
@@ -89,24 +89,31 @@ class URDFLoader {
     /* Public API */
     // urdf:    The path to the URDF within the package OR absolute
     // packages:     The equivelant of a (list of) ROS package(s):// directory
-    // cb:      Callback that is passed the model once loaded
-    load(urdf, packages, onComplete, loadMeshCb, fetchOptions) {
+    // onComplete:      Callback that is passed the model once loaded
+    load(urdf, packages, onComplete, options) {
+
+        options = Object.assign({}, options);
 
         // Check if a full URI is specified before
         // prepending the package info
-
-        const workingPath = this.path === undefined ? THREE.LoaderUtils.extractUrlBase(urdf) : this.path;
+        const workingPath = THREE.LoaderUtils.extractUrlBase(urdf);
         const urdfPath = this.manager.resolveURL(urdf);
 
-        fetch(urdfPath, fetchOptions)
+        fetch(urdfPath, options.fetchOptions)
             .then(res => res.text())
-            .then(data => this.parse(data, packages, workingPath, onComplete, loadMeshCb));
+            .then(data => this.parse(data, packages, workingPath, onComplete, options));
 
     }
 
-    parse(content, packages, path, onComplete, loadMeshCb) {
+    parse(content, packages, path, onComplete, options) {
 
-        const result = this._processUrdf(content, packages, path, loadMeshCb || this.defaultMeshLoader.bind(this));
+        options = Object.assign({
+
+            loadMeshCb: this.defaultMeshLoader.bind(this),
+
+        }, options);
+
+        const result = this._processUrdf(content, packages, path, options.loadMeshCb);
 
         if (typeof onComplete === 'function') {
 

--- a/javascript/URDFLoader.js
+++ b/javascript/URDFLoader.js
@@ -90,7 +90,7 @@ class URDFLoader {
     // urdf:    The path to the URDF within the package OR absolute
     // packages:     The equivelant of a (list of) ROS package(s):// directory
     // cb:      Callback that is passed the model once loaded
-    load(urdf, packages, cb, loadMeshCb, fetchOptions) {
+    load(urdf, packages, onComplete, loadMeshCb, fetchOptions) {
 
         // Check if a full URI is specified before
         // prepending the package info
@@ -100,13 +100,20 @@ class URDFLoader {
 
         fetch(urdfPath, fetchOptions)
             .then(res => res.text())
-            .then(data => this.parse(data, packages, cb, loadMeshCb, workingPath));
+            .then(data => this.parse(data, packages, workingPath, onComplete, loadMeshCb));
 
     }
 
-    parse(content, packages, cb, loadMeshCb, path) {
+    parse(content, packages, path, onComplete, loadMeshCb) {
 
-        cb(this._processUrdf(content, packages, path, loadMeshCb || this.defaultMeshLoader.bind(this)));
+        const result = this._processUrdf(content, packages, path, loadMeshCb || this.defaultMeshLoader.bind(this));
+
+        if (typeof onComplete === 'function') {
+
+            onComplete(result);
+        }
+
+        return result;
 
     }
 

--- a/javascript/urdf-viewer-element.js
+++ b/javascript/urdf-viewer-element.js
@@ -439,8 +439,8 @@ class URDFViewer extends HTMLElement {
             }
 
             this.urdfLoader.load(
-                pkg,
                 urdf,
+                pkg,
 
                 // Callback with array of robots
                 robot => {

--- a/javascript/urdf-viewer-element.js
+++ b/javascript/urdf-viewer-element.js
@@ -467,29 +467,34 @@ class URDFViewer extends HTMLElement {
 
                 },
 
-                // Load meshes and enable shadow casting
-                (path, ext, done) => {
+                // options
+                {
+                    loadMeshCb: (path, ext, done) => {
 
-                    totalMeshes++;
-                    this.urdfLoader.defaultMeshLoader(path, ext, mesh => {
+                        // Load meshes and enable shadow casting
+                        totalMeshes++;
+                        this.urdfLoader.defaultMeshLoader(path, ext, mesh => {
 
-                        updateMaterials(mesh);
+                            updateMaterials(mesh);
 
-                        done(mesh);
+                            done(mesh);
 
-                        meshesLoaded++;
-                        if (meshesLoaded === totalMeshes && this._requestId === requestId) {
+                            meshesLoaded++;
+                            if (meshesLoaded === totalMeshes && this._requestId === requestId) {
 
-                            this.dispatchEvent(new CustomEvent('geometry-loaded', { bubbles: true, cancelable: true, composed: true }));
+                                this.dispatchEvent(new CustomEvent('geometry-loaded', { bubbles: true, cancelable: true, composed: true }));
 
-                        }
+                            }
 
-                        this._dirty = true;
+                            this._dirty = true;
 
-                    });
+                        });
 
-                },
-                { mode: 'cors', credentials: 'same-origin' });
+                    },
+
+                    fetchOptions: { mode: 'cors', credentials: 'same-origin' },
+
+                });
 
         }
 


### PR DESCRIPTION
- `parse` function signature changed
- `parse` returns the robot now
- `meshLoadCb` and `fetchOptions` have been moved into an `options` argument object