### PR TITLE
Focus camera once

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -251,6 +251,10 @@ The color of the ambient light specified with css colors.
 
 Automatically redraw the model every frame instead of waiting to be dirtied.
 
+#### no-auto-recenter
+
+Recenter the camera only after loading the model or if the window size changes.
+
 ### Properties
 
 All of the above attributes have corresponding camel case properties.
@@ -272,6 +276,10 @@ Sets all joint names specified as keys to radian angle value.
 #### redraw()
 
 Dirty the renderer so the element will redraw next frame.
+
+#### recenter()
+
+Recenter the camera to the model and redraw.
 
 ### Events
 

--- a/javascript/urdf-viewer-element.js
+++ b/javascript/urdf-viewer-element.js
@@ -38,6 +38,9 @@ class URDFViewer extends HTMLElement {
     get autoRedraw() { return this.hasAttribute('auto-redraw') || false; }
     set autoRedraw(val) { val ? this.setAttribute('auto-redraw', true) : this.removeAttribute('auto-redraw'); }
 
+    get noAutoRecenter() { return this.hasAttribute('no-auto-recenter') || false; }
+    set noAutoRecenter(val) { val ? this.setAttribute('no-auto-recenter', true) : this.removeAttribute('no-auto-recenter'); }
+
     get loadingManager() { return this._loadingManager = this._loadingManager || new THREE.LoadingManager(); }
 
     get urdfLoader() { return this._urdfLoader = this._urdfLoader || new URDFLoader(this.loadingManager); }
@@ -120,7 +123,7 @@ class URDFViewer extends HTMLElement {
         controls.enableDamping = false;
         controls.maxDistance = 50;
         controls.minDistance = 0.25;
-        controls.addEventListener('change', () => this._dirty = true);
+        controls.addEventListener('change', () => this.recenter());
 
         this.scene = scene;
         this.world = world;
@@ -134,7 +137,7 @@ class URDFViewer extends HTMLElement {
         this._setUp(this.up);
 
         // redraw when something new has loaded
-        this.loadingManager.onLoad = () => this._dirty = true;
+        this.loadingManager.onLoad = () => this.recenter();
 
         const _renderLoop = () => {
 
@@ -144,20 +147,19 @@ class URDFViewer extends HTMLElement {
 
                 if (this._dirty || this.autoRedraw) {
 
-                    this._updateEnvironment();
+                    if (!this.noAutoRecenter) {
+
+                        this._updateEnvironment();
+                    }
+
+                    this.renderer.render(scene, camera);
+                    this._dirty = false;
 
                 }
 
                 // update controls after the environment in
                 // case the controls are retargeted
                 this.controls.update();
-
-                if (this._dirty || this.autoRedraw) {
-
-                    this.renderer.render(scene, camera);
-                    this._dirty = false;
-
-                }
 
             }
             this._renderLoopId = requestAnimationFrame(_renderLoop);
@@ -207,7 +209,7 @@ class URDFViewer extends HTMLElement {
 
     attributeChangedCallback(attr, oldval, newval) {
 
-        this._dirty = true;
+        this.recenter();
 
         switch (attr) {
 
@@ -255,7 +257,7 @@ class URDFViewer extends HTMLElement {
 
         if (currsize.width !== w || currsize.height !== h) {
 
-            this._dirty = true;
+            this.recenter();
 
         }
 
@@ -270,6 +272,12 @@ class URDFViewer extends HTMLElement {
     redraw() {
 
         this._dirty = true;
+    }
+
+    recenter() {
+
+        this._updateEnvironment();
+        this.redraw();
 
     }
 
@@ -283,7 +291,7 @@ class URDFViewer extends HTMLElement {
         if (joint && joint.angle !== angle) {
 
             joint.setAngle(angle);
-            this._dirty = true;
+            this.redraw();
 
         }
 
@@ -303,9 +311,6 @@ class URDFViewer extends HTMLElement {
     // camera on the center of the scene
     _updateEnvironment() {
 
-        const dirLight = this.directionalLight;
-        dirLight.castShadow = this.displayShadow;
-
         if (!this.robot) return;
 
         this.world.updateMatrixWorld();
@@ -314,6 +319,9 @@ class URDFViewer extends HTMLElement {
         const center = bbox.getCenter(new THREE.Vector3());
         this.controls.target.y = center.y;
         this.plane.position.y = bbox.min.y - 1e-3;
+
+        const dirLight = this.directionalLight;
+        dirLight.castShadow = this.displayShadow;
 
         if (this.displayShadow) {
 
@@ -470,7 +478,7 @@ class URDFViewer extends HTMLElement {
 
                     this.dispatchEvent(new CustomEvent('urdf-processed', { bubbles: true, cancelable: true, composed: true }));
 
-                    this._dirty = true;
+                    this.recenter();
 
                 },
 
@@ -493,7 +501,7 @@ class URDFViewer extends HTMLElement {
 
                             }
 
-                            this._dirty = true;
+                            this.recenter();
 
                         });
 

--- a/javascript/urdf-viewer-element.js
+++ b/javascript/urdf-viewer-element.js
@@ -305,14 +305,17 @@ class URDFViewer extends HTMLElement {
 
         const dirLight = this.directionalLight;
         dirLight.castShadow = this.displayShadow;
-        if (this.robot && this.displayShadow) {
 
-            this.world.updateMatrixWorld();
+        if (!this.robot) return;
 
-            const bbox = new THREE.Box3().setFromObject(this.robot);
-            const center = bbox.getCenter(new THREE.Vector3());
-            this.controls.target.y = center.y;
-            this.plane.position.y = bbox.min.y - 1e-3;
+        this.world.updateMatrixWorld();
+
+        const bbox = new THREE.Box3().setFromObject(this.robot);
+        const center = bbox.getCenter(new THREE.Vector3());
+        this.controls.target.y = center.y;
+        this.plane.position.y = bbox.min.y - 1e-3;
+
+        if (this.displayShadow) {
 
             // Update the shadow camera rendering bounds to encapsulate the
             // model. We use the bounding sphere of the bounding box for


### PR DESCRIPTION
### Fix: 
If `display-shadow` is `false` the camera did not centre the robot model.

### New attribute: 
`focus-camera-once`: The camera focuses the model when `_dirty=true` (after loading the model or changing the window. )but not if the robot moves. 

In order to differentiate, the function `setAngle()` triggers now  `_robotMoved` and not `_dirty`.

This is related to https://github.com/gkjohnson/urdf-loaders/issues/44.