### PR TITLE
Load only mesh of DAE

### DIFF
--- a/javascript/URDFLoader.js
+++ b/javascript/URDFLoader.js
@@ -141,7 +141,20 @@ class URDFLoader {
 
         } else if (/\.dae$/i.test(path)) {
 
-            this.DAELoader.load(path, dae => done(dae.scene));
+            this.DAELoader.load(path, dae => {
+
+                for (let i = dae.scene.children.length - 1; i >= 0; i--) {
+
+                    if (dae.scene.children[i].type !== 'Mesh') {
+
+                        dae.scene.remove(dae.scene.children[i]);
+
+                    }
+                }
+
+                done(dae.scene);
+
+            });
 
         } else {
 


### PR DESCRIPTION
Filters the mesh out of the imported DAE files and thus, removes the camera and the light.
This solves the issue of having a too bright lightning and also speeds up the import a lot.

I thought about adding another attribute to turn on/off this feature, but for the case of an URDF I do not see any utilization of the link's lightning (and the code would get ugly since the import is very nested).
