### PR TITLE
Fix howto start example

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -305,7 +305,7 @@ Install Node.js and NPM.
 
 Run `npm install`.
 
-Run `npm run server`.
+Run `npm start`.
 
 Visit `localhost:9080/javascript/example/` to view the page.
 


### PR DESCRIPTION
The current command is failing

```sh
$ npm run server
npm ERR! missing script: server
```
I guess it should be (I tested it and it worked)

```
npm start
```