### PR TITLE
Add URDFCollider flag, tests

### DIFF
--- a/javascript/src/URDFClasses.d.ts
+++ b/javascript/src/URDFClasses.d.ts
@@ -1,5 +1,11 @@
 import { Object3D, Vector3 } from 'three';
 
+export class URDFCollider extends Object3D {
+
+    isURDFCollider: true;
+
+}
+
 export class URDFLink extends Object3D {
 
     isURDFLink: true;

--- a/javascript/src/URDFClasses.js
+++ b/javascript/src/URDFClasses.js
@@ -1,5 +1,21 @@
 import { Object3D, Quaternion } from 'three';
 
+function URDFColliderClone(...args) {
+
+    const proto = Object.getPrototypeOf(this);
+    const result = proto.clone.call(this, ...args);
+    result.isURDFCollider = true;
+    return result;
+
+};
+
+function makeURDFCollider(object) {
+
+    object.isURDFCollider = true;
+    object.clone = URDFColliderClone;
+
+}
+
 class URDFLink extends Object3D {
 
     constructor(...args) {
@@ -246,4 +262,4 @@ class URDFRobot extends URDFLink {
 
 }
 
-export { URDFRobot, URDFLink, URDFJoint };
+export { URDFRobot, URDFLink, URDFJoint, makeURDFCollider };

--- a/javascript/src/URDFLoader.js
+++ b/javascript/src/URDFLoader.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { STLLoader } from 'three/examples/js/loaders/STLLoader';
 import { ColladaLoader } from 'three/examples/js/loaders/ColladaLoader';
-import { URDFRobot, URDFJoint, URDFLink } from './URDFClasses.js';
+import { URDFRobot, URDFJoint, URDFLink, makeURDFCollider } from './URDFClasses.js';
 
 /*
 Reference coordinate frames for THREE.js and ROS.
@@ -337,6 +337,7 @@ class URDFLoader {
         // Process the visual and collision nodes into meshes
         function processLinkElement(vn, linkObj, materialMap = {}) {
 
+            const isCollisionNode = vn.nodeName.toLowerCase() === 'collision';
             let xyz = [0, 0, 0];
             let rpy = [0, 0, 0];
             let scale = [1, 1, 1];
@@ -412,6 +413,12 @@ class URDFLoader {
 
                                     applyRotation(obj, rpy);
 
+                                    if (isCollisionNode) {
+
+                                        makeURDFCollider(obj);
+
+                                    }
+
                                 }
 
                             });
@@ -429,6 +436,12 @@ class URDFLoader {
                         linkObj.add(primitiveModel);
                         primitiveModel.scale.set(size[0], size[1], size[2]);
 
+                        if (isCollisionNode) {
+
+                            makeURDFCollider(primitiveModel);
+
+                        }
+
                     } else if (geoType === 'sphere') {
 
                         primitiveModel = new THREE.Mesh();
@@ -439,6 +452,12 @@ class URDFLoader {
                         primitiveModel.scale.set(radius, radius, radius);
 
                         linkObj.add(primitiveModel);
+
+                        if (isCollisionNode) {
+
+                            makeURDFCollider(primitiveModel);
+
+                        }
 
                     } else if (geoType === 'cylinder') {
 
@@ -452,6 +471,12 @@ class URDFLoader {
                         primitiveModel.rotation.set(Math.PI / 2, 0, 0);
 
                         linkObj.add(primitiveModel);
+
+                        if (isCollisionNode) {
+
+                            makeURDFCollider(primitiveModel);
+
+                        }
 
                     }
 

--- a/javascript/test/test.js
+++ b/javascript/test/test.js
@@ -45,6 +45,92 @@ beforeAll(async() => {
 
 describe('Options', () => {
 
+    describe('parseVisual, parseCollision', () => {
+
+        it('should exclude the elements if false', async() => {
+
+            await loadURDF(
+                page,
+                'https://raw.githubusercontent.com/gkjohnson/nasa-urdf-robots/master/r2_description/robots/r2b.urdf',
+                {
+                    packages: 'https://raw.githubusercontent.com/gkjohnson/nasa-urdf-robots/master/',
+                    parseVisual: false,
+                    parseCollision: false,
+                },
+            );
+
+            const counts = await page.evaluate(async() => {
+
+                let totalVisual = 0;
+                let totalCollision = 0;
+                window.robot.traverse(c => {
+
+                    if (c.isURDFLink) {
+
+                        const children = c.children;
+                        const joints = children.filter(c2 => c2.isURDFJoint).length;
+                        const collision = children.filter(c2 => c2.isURDFCollider).length;
+                        const visual = children.length - joints - collision;
+
+                        totalVisual += visual;
+                        totalCollision += collision;
+
+                    }
+
+                });
+
+                return { visual: totalVisual, collision: totalCollision };
+
+            });
+
+            expect(counts.visual).toBe(0);
+            expect(counts.collision).toBe(0);
+
+        });
+
+        it('should include the elements if true', async() => {
+
+            await loadURDF(
+                page,
+                'https://raw.githubusercontent.com/gkjohnson/nasa-urdf-robots/master/r2_description/robots/r2b.urdf',
+                {
+                    packages: 'https://raw.githubusercontent.com/gkjohnson/nasa-urdf-robots/master/',
+                    parseVisual: true,
+                    parseCollision: true,
+                },
+            );
+
+            const counts = await page.evaluate(async() => {
+
+                let totalVisual = 0;
+                let totalCollision = 0;
+                window.robot.traverse(c => {
+
+                    if (c.isURDFLink) {
+
+                        const children = c.children;
+                        const joints = children.filter(c2 => c2.isURDFJoint).length;
+                        const collision = children.filter(c2 => c2.isURDFCollider).length;
+                        const visual = children.length - joints - collision;
+
+                        totalVisual += visual;
+                        totalCollision += collision;
+
+                    }
+
+                });
+
+                return { visual: totalVisual, collision: totalCollision };
+
+            });
+
+            expect(counts.visual).toBe(71);
+            expect(counts.collision).toBe(71);
+
+        });
+
+    });
+
     describe('loadMeshCb', () => {
 
         it('should get called to load all meshes', async() => {
@@ -99,10 +185,11 @@ describe('Clone', () => {
 
         await loadURDF(
             page,
-            'https://raw.githubusercontent.com/gkjohnson/urdf-loaders/master/urdf/TriATHLETE_Climbing/urdf/TriATHLETE.URDF',
+            'https://raw.githubusercontent.com/gkjohnson/nasa-urdf-robots/master/r2_description/robots/r2b.urdf',
             {
-                packages: 'https://raw.githubusercontent.com/gkjohnson/urdf-loaders/master/urdf/TriATHLETE_Climbing',
-            }
+                packages: 'https://raw.githubusercontent.com/gkjohnson/nasa-urdf-robots/master/',
+                parseCollision: true,
+            },
         );
 
         const robotsAreEqual = await page.evaluate(async() => {
@@ -115,6 +202,12 @@ describe('Clone', () => {
                 areEqual = areEqual && ra.geometry === rb.geometry;
                 areEqual = areEqual && ra.material === rb.material;
                 areEqual = areEqual && ra.urdfNode === rb.urdfNode;
+
+                areEqual = areEqual && ra.isMesh === rb.isMesh;
+                areEqual = areEqual && ra.isURDFLink === rb.isURDFLink;
+                areEqual = areEqual && ra.isURDFRobot === rb.isURDFRobot;
+                areEqual = areEqual && ra.isURDFJoint === rb.isURDFJoint;
+                areEqual = areEqual && ra.isURDFCollider === rb.isURDFCollider;
 
                 switch (ra.type) {
 


### PR DESCRIPTION
- Modify the loaded mesh objects in place to add the `isURDFCollider` and update the clone function to include the flag, as well.
- Add tests to verify the new `parseVisual` and `parseCollision` options.

Related to #122.
Fix #130

/ping @chaitanya-deep if you're interested in taking a look!