### PR TITLE
Fix for typescript error TS1036

### DIFF
--- a/javascript/src/URDFLoader.d.ts
+++ b/javascript/src/URDFLoader.d.ts
@@ -16,7 +16,8 @@ interface URDFLoaderOptions {
     workingPath?: string,
     fetchOptions?: object
 
-};
+}
+
 export default class URDFLoader {
 
     manager: LoadingManager;


### PR DESCRIPTION
When importing URDFLoader in typescript: `import URDFLoader from 'urdf-loader/src/URDFLoader';`

I get the following error:
`ERROR in node_modules/urdf-loader/src/URDFLoader.d.ts(19,2): error TS1036: Statements are not allowed in ambient contexts.`

The solution is simply to remove the ";"
Thanks!