### PR TITLE
Copyright update

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,8 @@ The `_flipped` variants of the URDF ATHLETE models invert the revolute joint axe
 
 The software is available under the [Apache V2.0 license](../LICENSE.txt).
 
-Copyright © 2018 California Institute of Technology. ALL RIGHTS
-RESERVED. United States Government Sponsorship Acknowledged. Any
-commercial use must be negotiated with with Office of Technology
-Transfer at the California Institute of Technology. This software may
+Copyright © 2019 California Institute of Technology. ALL RIGHTS
+RESERVED. United States Government Sponsorship Acknowledged. This software may
 be subject to U.S. export control laws. By accepting this software,
 the user agrees to comply with all applicable U.S. export laws and
 regulations. User has the responsibility to obtain export licenses,

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -399,10 +399,8 @@ Visit `localhost:9080/javascript/example/` to view the page.
 
 The software is available under the [Apache V2.0 license](../LICENSE.txt).
 
-Copyright © 2018 California Institute of Technology. ALL RIGHTS
-RESERVED. United States Government Sponsorship Acknowledged. Any
-commercial use must be negotiated with with Office of Technology
-Transfer at the California Institute of Technology. This software may
+Copyright © 2019 California Institute of Technology. ALL RIGHTS
+RESERVED. United States Government Sponsorship Acknowledged. This software may
 be subject to U.S. export control laws. By accepting this software,
 the user agrees to comply with all applicable U.S. export laws and
 regulations. User has the responsibility to obtain export licenses,

--- a/unity/Assets/URDF-Loader/README.md
+++ b/unity/Assets/URDF-Loader/README.md
@@ -83,10 +83,8 @@ Takes a `Dictionary<string, float>` and sets all the angles on the robot that ar
 
 The software is available under the [Apache V2.0 license](../LICENSE.txt).
 
-Copyright © 2018 California Institute of Technology. ALL RIGHTS
-RESERVED. United States Government Sponsorship Acknowledged. Any
-commercial use must be negotiated with with Office of Technology
-Transfer at the California Institute of Technology. This software may
+Copyright © 2019 California Institute of Technology. ALL RIGHTS
+RESERVED. United States Government Sponsorship Acknowledged. This software may
 be subject to U.S. export control laws. By accepting this software,
 the user agrees to comply with all applicable U.S. export laws and
 regulations. User has the responsibility to obtain export licenses,


### PR DESCRIPTION
Per a discussion 09/11/2019 permission has been given to remove the commercialization clause for the use of the software in the copyright statement.

In progress.