### PR TITLE
support onProgress, onError callbacks on URDFLoader.load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Jetbrains IDE files
+**/.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
   - node
-before_install:
-  - cd javascript
 script:
   - npm run lint
   - npm run build

--- a/javascript/src/URDFLoader.d.ts
+++ b/javascript/src/URDFLoader.d.ts
@@ -24,7 +24,13 @@ export default class URDFLoader {
     defaultMeshLoader: MeshLoadFunc;
 
     constructor(manager?: LoadingManager);
-    load(url: string, onLoad: (robot: URDFRobot) => void, options?: URDFLoaderOptions): void;
+    load(
+        url: string,
+        onLoad: (robot: URDFRobot, errors?: { [url: string]: string }) => void,
+        onProgress: (url: string, itemsLoaded: number, itemsTotal: number) => void,
+        onError: (url: string) => void,
+        options?: URDFLoaderOptions
+    ): void;
     parse(content: string, options?: URDFLoaderOptions): URDFRobot;
 
 }

--- a/javascript/src/urdf-viewer-element.js
+++ b/javascript/src/urdf-viewer-element.js
@@ -500,7 +500,15 @@ class URDFViewer extends HTMLElement {
 
             new URDFLoader(manager).load(
                 urdf,
-                model => robot = model,
+
+                // onComplete
+                (model, errors) => (robot = model),
+
+                // onProgress
+                (url, itemsLoaded, itemsTotal) => null,
+
+                // onError
+                (url) => null,
 
                 // options
                 {

--- a/javascript/test/test.js
+++ b/javascript/test/test.js
@@ -157,6 +157,8 @@ describe('Options', () => {
                             resolve(ct);
 
                         },
+                        null,
+                        null,
                         {
                             packages: 'https://raw.githubusercontent.com/gkjohnson/urdf-loaders/master/urdf/TriATHLETE_Climbing',
                             loadMeshCb: (path, manager, done) => {
@@ -364,13 +366,13 @@ describe('TriATHLETE Climbing URDF', () => {
         urdf: 'https://raw.githubusercontent.com/ipa-jfh/urdf-loaders/2170f75bacaec933c17aeb2ee59d73643a4bab3a/multipkg_test.urdf',
         pkg: {
             blending_end_effector:
-            'https://raw.githubusercontent.com/ros-industrial-consortium/godel/kinetic-devel/godel_robots/blending_end_effector',
+                'https://raw.githubusercontent.com/ros-industrial-consortium/godel/kinetic-devel/godel_robots/blending_end_effector',
 
             abb_irb1200_support:
-            'https://raw.githubusercontent.com/ros-industrial/abb_experimental/kinetic-devel/abb_irb1200_support',
+                'https://raw.githubusercontent.com/ros-industrial/abb_experimental/kinetic-devel/abb_irb1200_support',
 
             godel_irb1200_support:
-            'https://raw.githubusercontent.com/ros-industrial-consortium/godel/kinetic-devel/godel_robots/abb/godel_irb1200/godel_irb1200_support',
+                'https://raw.githubusercontent.com/ros-industrial-consortium/godel/kinetic-devel/godel_robots/abb/godel_irb1200/godel_irb1200_support',
         },
     },
 ].forEach(data => {

--- a/javascript/test/test.js
+++ b/javascript/test/test.js
@@ -366,13 +366,13 @@ describe('TriATHLETE Climbing URDF', () => {
         urdf: 'https://raw.githubusercontent.com/ipa-jfh/urdf-loaders/2170f75bacaec933c17aeb2ee59d73643a4bab3a/multipkg_test.urdf',
         pkg: {
             blending_end_effector:
-                'https://raw.githubusercontent.com/ros-industrial-consortium/godel/kinetic-devel/godel_robots/blending_end_effector',
+            'https://raw.githubusercontent.com/ros-industrial-consortium/godel/kinetic-devel/godel_robots/blending_end_effector',
 
             abb_irb1200_support:
-                'https://raw.githubusercontent.com/ros-industrial/abb_experimental/kinetic-devel/abb_irb1200_support',
+            'https://raw.githubusercontent.com/ros-industrial/abb_experimental/kinetic-devel/abb_irb1200_support',
 
             godel_irb1200_support:
-                'https://raw.githubusercontent.com/ros-industrial-consortium/godel/kinetic-devel/godel_robots/abb/godel_irb1200/godel_irb1200_support',
+            'https://raw.githubusercontent.com/ros-industrial-consortium/godel/kinetic-devel/godel_robots/abb/godel_irb1200/godel_irb1200_support',
         },
     },
 ].forEach(data => {

--- a/javascript/test/utils.js
+++ b/javascript/test/utils.js
@@ -45,6 +45,9 @@ function loadURDF(page, urdf, options = {}) {
 
                 },
 
+                null,
+                null,
+
                 options2
 
             );


### PR DESCRIPTION
Hi

This PR addresses https://github.com/gkjohnson/urdf-loaders/issues/95

It adds the following callbacks to the `URDFLoader.load` function:

1. `onError(url) => void`: triggered on individual errors for each resource
2. `onProgress(url, itemsLoaded, itemsTotal) => void`: triggered on individual load for each resource
 
Changes to existing functions:

1. `onComplete(model, errors: { [url]: string }) => void`: triggered after all link mesh loads are attempted and either succeed or fail

I have updated the existing tests to pass but have a doubt about writing tests for the above functionality.

Adding new tests seems to modify the `window.model` object that causes other tests to fail. Should I add the new tests at the bottom instead?

Thanks!