### PR TITLE
Don't try and load empty textures

### DIFF
--- a/javascript/src/URDFLoader.js
+++ b/javascript/src/URDFLoader.js
@@ -322,10 +322,12 @@ class URDFLoader {
 
                 } else if (type === 'texture') {
 
-                    const loader = new THREE.TextureLoader(manager);
                     const filename = n.getAttribute('filename');
-                    const filePath = resolvePath(filename);
-                    material.map = loader.load(filePath);
+                    if(filename && filename != "") {
+                      const loader = new THREE.TextureLoader(manager);
+                      const filePath = resolvePath(filename);
+                      material.map = loader.load(filePath);
+                    }
 
                 }
             });

--- a/javascript/src/URDFLoader.js
+++ b/javascript/src/URDFLoader.js
@@ -323,10 +323,10 @@ class URDFLoader {
                 } else if (type === 'texture') {
 
                     const filename = n.getAttribute('filename');
-                    if(filename && filename != "") {
-                      const loader = new THREE.TextureLoader(manager);
-                      const filePath = resolvePath(filename);
-                      material.map = loader.load(filePath);
+                    if (filename) {
+                        const loader = new THREE.TextureLoader(manager);
+                        const filePath = resolvePath(filename);
+                        material.map = loader.load(filePath);
                     }
 
                 }


### PR DESCRIPTION
Many URDFs we parse (having been generated with https://github.com/ros/urdfdom) have empty texture attributes like so:

```xml
          <material name="dark_grey">
                <texture />
                <color rgba="0.1 0.1 0.1 1" />
            </material>
```

When the current urdf-loaders encounters this, it makes a request to the server for "null" as the url. When that 404s it ruins the texture of the entire scene.