### PR TITLE
Allow URDFLoader.packages to be a function

### DIFF
--- a/javascript/src/URDFLoader.d.ts
+++ b/javascript/src/URDFLoader.d.ts
@@ -19,7 +19,7 @@ export default class URDFLoader {
     workingPath: string;
     parseVisual: boolean;
     parseCollision: boolean;
-    packages: string | { [key: string]: string };
+    packages: string | { [key: string]: string } | ((targetPkg: string) => string);
     loadMeshCb: MeshLoadFunc;
 
     constructor(manager?: LoadingManager);


### PR DESCRIPTION
This code path seems not to be covered by the TS type definitions. `packages` is currently required to be `string | { [key: string]: string }`.

https://github.com/gkjohnson/urdf-loaders/blob/9e162325b602f83b48efa9459e000fbb4b001eb2/javascript/src/URDFLoader.js#L183-L185