### PR TITLE
Remove console warning from mimic joint value set

### DIFF
--- a/javascript/src/URDFClasses.js
+++ b/javascript/src/URDFClasses.js
@@ -266,13 +266,6 @@ class URDFMimicJoint extends URDFJoint {
     }
 
     /* Overrides */
-    setJointValue(...values) {
-
-        console.warn(`URDFMimicJoint: Setting the joint value of mimic joint "${ this.urdfName }" will cause it to be out of sync.`);
-        return super.setJointValue(...values);
-    }
-
-    /* Overrides */
     copy(source, recursive) {
 
         super.copy(source, recursive);


### PR DESCRIPTION
Fixes #252.

Removes an override on the `URDFMimicJoint` class that logs a warning when attempting to set the value of a mimic joint. It is fairly common to set mimic joint values in some robotic simulation ecosystems, because the joints are mimics in real life but simulated individually.