### PR TITLE
Add support method THREE.BoxGeometry

### DIFF
--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -28,7 +28,7 @@
         "typescript": "^3.9.7"
       },
       "peerDependencies": {
-        "three": ">=0.105.0"
+        "three": ">=0.144.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -36,7 +36,7 @@
     "webcomponents"
   ],
   "peerDependencies": {
-    "three": ">=0.105.0"
+    "three": ">=0.144.0"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/javascript/src/URDFLoader.js
+++ b/javascript/src/URDFLoader.js
@@ -593,7 +593,7 @@ class URDFLoader {
                     } else if (geoType === 'sphere') {
 
                         const primitiveModel = new THREE.Mesh();
-                        primitiveModel.geometry = new THREE.SphereBufferGeometry(1, 30, 30);
+                        primitiveModel.geometry = new THREE.SphereGeometry(1, 30, 30);
                         primitiveModel.material = material;
 
                         const radius = parseFloat(n.children[0].getAttribute('radius')) || 0;
@@ -604,7 +604,7 @@ class URDFLoader {
                     } else if (geoType === 'cylinder') {
 
                         const primitiveModel = new THREE.Mesh();
-                        primitiveModel.geometry = new THREE.CylinderBufferGeometry(1, 1, 1, 30);
+                        primitiveModel.geometry = new THREE.CylinderGeometry(1, 1, 1, 30);
                         primitiveModel.material = material;
 
                         const radius = parseFloat(n.children[0].getAttribute('radius')) || 0;

--- a/javascript/src/URDFLoader.js
+++ b/javascript/src/URDFLoader.js
@@ -582,7 +582,7 @@ class URDFLoader {
                     } else if (geoType === 'box') {
 
                         const primitiveModel = new THREE.Mesh();
-                        primitiveModel.geometry = new THREE.BoxBufferGeometry(1, 1, 1);
+                        primitiveModel.geometry = new THREE.BoxGeometry(1, 1, 1);
                         primitiveModel.material = material;
 
                         const size = processTuple(n.children[0].getAttribute('size'));


### PR DESCRIPTION
Three.js renamed `THREE.BoxBufferGeometry` to `THREE.BoxGeometry`.
It shows some warnings.