### PR TITLE
Don't parseFloat null values in setJointValue

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -301,10 +301,10 @@ A list of joints which mimic this joint. These joints are updated whenever this 
 ### .setJointValue
 
 ```js
-setJointValue( jointValue : number ) : Boolean
+setJointValue( ...jointValues : (number | null)[] ) : Boolean
 ```
 
-Sets the joint value for the given joint. The interpretation of the value depends on the joint type. If the joint value specifies an angle it must be in radians.
+Sets the joint value(s) for the given joint. The interpretation of the value depends on the joint type. If the joint value specifies an angle it must be in radians. If the value specifies a distance, it must be in meters. Passing null for any component of the value will skip updating that particular component.
 
 Returns true if the joint or any of its mimicking joints changed.
 
@@ -509,10 +509,10 @@ Sets or gets the jointValues of the robot as a dictionary of `joint-name` to `ra
 #### .setJointValue
 
 ```js
-setJointValue( jointName : String, jointValue : Number ) : void
+setJointValue( jointName : String, ...jointValues : (number | null)[] ) : void
 ```
 
-Sets the given joint to the provided angle in radians.
+Sets the given joint to the provided value(s). See URDFJoint.setJointValue.
 
 #### .setJointValues
 

--- a/javascript/src/URDFClasses.d.ts
+++ b/javascript/src/URDFClasses.d.ts
@@ -34,7 +34,7 @@ export interface URDFJoint extends Object3D {
     ignoreLimits: Boolean;
     mimicJoints: URDFMimicJoint[];
 
-    setJointValue(value0: Number, value1?: Number, value2?: Number): boolean;
+    setJointValue(...values: (number | null)[]): boolean;
 
 }
 

--- a/javascript/src/URDFClasses.js
+++ b/javascript/src/URDFClasses.js
@@ -147,9 +147,14 @@ class URDFJoint extends URDFBase {
     }
 
     /* Public Functions */
+    /**
+     * @param {...number|null} values The joint value components to set, optionally null for no-op
+     * @returns {boolean} Whether the invocation of this function resulted in an actual change to the joint value
+     */
     setJointValue(...values) {
 
-        values = values.map(v => parseFloat(v));
+        // Parse all incoming values into numbers except null, which we treat as a no-op for that value component.
+        values = values.map(v => v === null ? null : parseFloat(v));
 
         if (!this.origPosition || !this.origQuaternion) {
 


### PR DESCRIPTION
As discussed in #281:

Previously this code was parsing all values into numbers, including `null`, which we later attempt to use in the same function as a no-op. But with the current code, passing `null` would result in a `NaN`, making the if-null code unreachable.