### PR TITLE
Fix mimic joints pointing to the original robot after a clone

### DIFF
--- a/javascript/src/URDFClasses.js
+++ b/javascript/src/URDFClasses.js
@@ -342,6 +342,11 @@ class URDFRobot extends URDFLink {
 
         });
 
+        // Repair mimic joint references once we've re-accumulated all our joint data
+        for (const joint in this.joints) {
+            this.joints[joint].mimicJoints = this.joints[joint].mimicJoints.map((mimicJoint) => this.joints[mimicJoint.name]);
+        }
+
         this.frames = {
             ...this.colliders,
             ...this.visual,

--- a/javascript/test/URDFRobot.test.js
+++ b/javascript/test/URDFRobot.test.js
@@ -141,15 +141,20 @@ describe('URDFRobot', () => {
                 </joint>
                 <link name="LINK3"/>
             </robot>
-        `).clone();
+        `);
 
-        const jointB = res.joints['B'];
+        const cloned = res.clone();
+
+        const jointB = cloned.joints['B'];
         expect(jointB.mimicJoint).toEqual('A');
         expect(jointB.multiplier).toEqual(23);
         expect(jointB.offset).toEqual(-5);
 
-        const jointA = res.joints['A'];
+        const jointA = cloned.joints['A'];
         expect(jointA.mimicJoints.length).toEqual(1);
         expect(jointA.mimicJoints[0].name).toEqual('B');
+
+        // Expect the cloned joint not to be a reference to the joint on the robot that was cloned
+        expect(jointA.mimicJoints[0]).not.toBe(res.joints['A'].mimicJoints[0]);
     });
 });


### PR DESCRIPTION
Sometimes "I'll do it in a couple sprints" turns into "a year and a half later".

Fixes #229.

Adds an object equality test to the mimic joint tests that failed before I made the changes here.