### PR TITLE
Add case for `.obj` loader

### DIFF
--- a/javascript/src/URDFLoader.js
+++ b/javascript/src/URDFLoader.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js';
 import { ColladaLoader } from 'three/examples/jsm/loaders/ColladaLoader.js';
+import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js';
 import { URDFRobot, URDFJoint, URDFLink, URDFCollider, URDFVisual, URDFMimicJoint } from './URDFClasses.js';
 
 /*
@@ -652,6 +653,11 @@ class URDFLoader {
 
             const loader = new ColladaLoader(manager);
             loader.load(path, dae => done(dae.scene));
+
+        } else if (/\.obj$/i.test(path)) {
+
+            const loader = new OBJLoader(manager);
+            loader.load(path, obj => done(obj));
 
         } else {
 


### PR DESCRIPTION
This PR adds support for `.obj` meshes in `URDFLoader.js`