### PR TITLE
improve TS defintions

### DIFF
--- a/javascript/src/URDFClasses.d.ts
+++ b/javascript/src/URDFClasses.d.ts
@@ -28,10 +28,10 @@ export interface URDFJoint extends Object3D {
     urdfNode: Element | null;
     axis: Vector3;
     jointType: 'fixed' | 'continuous' | 'revolute' | 'planar' | 'prismatic' | 'floating';
-    angle: Number;
-    jointValue: Number[];
-    limit: { lower: Number, upper: Number }; // TODO: add more
-    ignoreLimits: Boolean;
+    angle: number;
+    jointValue: number[];
+    limit: { lower: number, upper: number }; // TODO: add more
+    ignoreLimits: boolean;
     mimicJoints: URDFMimicJoint[];
 
     setJointValue(...values: (number | null)[]): boolean;
@@ -40,9 +40,9 @@ export interface URDFJoint extends Object3D {
 
 export interface URDFMimicJoint extends URDFJoint {
 
-    mimicJoint : String;
-    offset: Number;
-    multiplier: Number;
+    mimicJoint: string;
+    offset: number;
+    multiplier: number;
 
 }
 
@@ -59,8 +59,8 @@ export interface URDFRobot extends URDFLink {
     visual: { [ key: string ]: URDFVisual };
     frames: { [ key: string ]: Object3D };
 
-    setJointValue(jointName: String, ...values: number[]): boolean;
-    setJointValues(values: { [ key: string ]: Number | Number[] }): boolean;
-    getFrame(name: String): Object3D;
+    setJointValue(jointName: string, ...values: number[]): boolean;
+    setJointValues(values: { [ key: string ]: number | number[] }): boolean;
+    getFrame(name: string): Object3D;
 
 }

--- a/javascript/src/URDFClasses.d.ts
+++ b/javascript/src/URDFClasses.d.ts
@@ -1,27 +1,31 @@
 import { Object3D, Vector3 } from 'three';
 
-export interface URDFCollider extends Object3D {
+declare class URDFBase extends Object3D {
+
+    urdfNode: Element | null;
+    urdfName: string;
+
+}
+
+export class URDFCollider extends URDFBase {
 
     isURDFCollider: true;
-    urdfNode: Element | null;
 
 }
 
-export interface URDFVisual extends Object3D {
+export class URDFVisual extends URDFBase {
 
     isURDFVisual: true;
-    urdfNode: Element | null;
 
 }
 
-export interface URDFLink extends Object3D {
+export class URDFLink extends URDFBase {
 
     isURDFLink: true;
-    urdfNode: Element | null;
 
 }
 
-export interface URDFJoint extends Object3D {
+export class URDFJoint extends URDFBase {
 
     isURDFJoint: true;
 
@@ -38,7 +42,7 @@ export interface URDFJoint extends Object3D {
 
 }
 
-export interface URDFMimicJoint extends URDFJoint {
+export class URDFMimicJoint extends URDFJoint {
 
     mimicJoint: string;
     offset: number;
@@ -46,7 +50,7 @@ export interface URDFMimicJoint extends URDFJoint {
 
 }
 
-export interface URDFRobot extends URDFLink {
+export class URDFRobot extends URDFLink {
 
     isURDFRobot: true;
 

--- a/javascript/src/URDFLoader.d.ts
+++ b/javascript/src/URDFLoader.d.ts
@@ -15,7 +15,7 @@ export default class URDFLoader {
     defaultMeshLoader: MeshLoadFunc;
 
     // options
-    fetchOptions: Object;
+    fetchOptions: RequestInit;
     workingPath: string;
     parseVisual: boolean;
     parseCollision: boolean;


### PR DESCRIPTION
This PR proposes small changes in the typescript definition:

1. Replace Capital letter types with primitive types.
   Capital letter types refer to wrapper objects that are instantiated as `const n = new Number(1)` and not as `const n = Number(1)` or `const n = 1` which are the primitive types. You can find [here](https://github.com/microsoft/TypeScript/blob/ac03ba4f021fce5a78bcdde39952879d0a4f35eb/src/lib/es5.d.ts#L541-L568) the es5 definition for Number but same applies to String, Boolean, Symbol, BigInt, and Object.
  Their use is discouraged in TypeScript and not used in this repo's .js files.
   > The type names String, Number, and Boolean (starting with capital letters) are legal, but refer to some special built-in types that will very rarely appear in your code. Always use string, number, or boolean for types.

    source <https://www.typescriptlang.org/docs/handbook/2/everyday-types.html>

2. set URDFLoader's fetchOptions type to be [`RequestInit`](https://github.com/microsoft/TypeScript/blob/ac03ba4f021fce5a78bcdde39952879d0a4f35eb/src/lib/dom.generated.d.ts#L1965-L1993) (as in [fetch's definition](https://github.com/microsoft/TypeScript/blob/ac03ba4f021fce5a78bcdde39952879d0a4f35eb/src/lib/dom.generated.d.ts#L28606))

3. Convert URDFClasses' interfaces to classes: this better reflects the underlying implementation of these classes.