### PR TITLE
feat: parse <inertial> elements from URDF links

### DIFF
--- a/javascript/src/URDFClasses.d.ts
+++ b/javascript/src/URDFClasses.d.ts
@@ -19,9 +19,21 @@ export class URDFVisual extends URDFBase {
 
 }
 
+export interface URDFInertial {
+
+    mass: number;
+    origin: { xyz: number[], rpy: number[] };
+    inertia: {
+        ixx: number; ixy: number; ixz: number;
+        iyy: number; iyz: number; izz: number;
+    };
+
+}
+
 export class URDFLink extends URDFBase {
 
     isURDFLink: true;
+    inertial: URDFInertial | null;
 
 }
 

--- a/javascript/src/URDFClasses.js
+++ b/javascript/src/URDFClasses.js
@@ -62,6 +62,32 @@ class URDFLink extends URDFBase {
         super(...args);
         this.isURDFLink = true;
         this.type = 'URDFLink';
+        this.inertial = null;
+
+    }
+
+    copy(source, recursive) {
+
+        super.copy(source, recursive);
+
+        if (source.inertial) {
+
+            this.inertial = {
+                mass: source.inertial.mass,
+                origin: {
+                    xyz: [...source.inertial.origin.xyz],
+                    rpy: [...source.inertial.origin.rpy],
+                },
+                inertia: { ...source.inertial.inertia },
+            };
+
+        } else {
+
+            this.inertial = null;
+
+        }
+
+        return this;
 
     }
 

--- a/javascript/src/URDFLoader.js
+++ b/javascript/src/URDFLoader.js
@@ -445,7 +445,53 @@ class URDFLoader {
 
             }
 
+            // Parse inertial properties
+            const inertialNode = children.find(n => n.nodeName.toLowerCase() === 'inertial');
+            if (inertialNode) {
+
+                target.inertial = processInertial(inertialNode);
+
+            }
+
             return target;
+
+        }
+
+        function processInertial(node) {
+
+            const children = [ ...node.children ];
+            const inertial = {
+                mass: 0,
+                origin: { xyz: [0, 0, 0], rpy: [0, 0, 0] },
+                inertia: { ixx: 0, ixy: 0, ixz: 0, iyy: 0, iyz: 0, izz: 0 },
+            };
+
+            children.forEach(n => {
+
+                const type = n.nodeName.toLowerCase();
+                if (type === 'mass') {
+
+                    inertial.mass = parseFloat(n.getAttribute('value')) || 0;
+
+                } else if (type === 'origin') {
+
+                    inertial.origin.xyz = processTuple(n.getAttribute('xyz'));
+                    inertial.origin.rpy = processTuple(n.getAttribute('rpy'));
+
+                } else if (type === 'inertia') {
+
+                    inertial.inertia.ixx = parseFloat(n.getAttribute('ixx')) || 0;
+                    inertial.inertia.ixy = parseFloat(n.getAttribute('ixy')) || 0;
+                    inertial.inertia.ixz = parseFloat(n.getAttribute('ixz')) || 0;
+                    inertial.inertia.iyy = parseFloat(n.getAttribute('iyy')) || 0;
+                    inertial.inertia.iyz = parseFloat(n.getAttribute('iyz')) || 0;
+                    inertial.inertia.izz = parseFloat(n.getAttribute('izz')) || 0;
+
+                }
+
+            });
+
+            return inertial;
 
         }
 


### PR DESCRIPTION
## Summary

- Parses `<inertial>` child elements from `<link>` nodes in URDF files
- Extracts `mass`, `origin` (xyz + rpy), and `inertia` (ixx, ixy, ixz, iyy, iyz, izz) into a new `inertial` property on `URDFLink`
- Adds `URDFInertial` TypeScript interface
- Adds `copy()` support to `URDFLink` for the new property

## Motivation

The URDF spec includes `<inertial>` data per link (mass, center of mass, inertia tensor), which is needed for dynamics computations like:
- Center of mass calculation
- Joint-space inertia matrix (composite rigid body algorithm)
- Acceleration ellipsoids
- ZMP / stability analysis

Currently urdf-loader parses visual/collision geometry and joint properties but skips inertial data entirely. This PR adds parsing following the same patterns used for joints (limits, axis) and link elements (visual, collision).

## Changes

- **`URDFClasses.js`**: Added `inertial` property (default `null`) to `URDFLink`, with `copy()` support
- **`URDFLoader.js`**: Added `processInertial()` function and call it from `processLink()`
- **`URDFClasses.d.ts`**: Added `URDFInertial` interface and typed `inertial` on `URDFLink`

## URDF reference

```xml
<link name="example">
  <inertial>
    <mass value="2.7"/>
    <origin xyz="0.0 0.0 0.1" rpy="0 0 0"/>
    <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.05"/>
  </inertial>
</link>
```