### PR TITLE
feat: parse <inertial> elements and joint effort/velocity limits

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -266,10 +266,10 @@ The type of joint. Can only be the URDF types of joints.
 ### .limit
 
 ```js
-.limit : { lower : number, upper : number }
+.limit : { lower : number, upper : number, effort : number, velocity : number }
 ```
 
-An object containing the `lower` and `upper` constraints for the joint.
+An object containing the `lower` and `upper` position constraints, as well as the `effort` and `velocity` limits for the joint. All fields default to zero if not specified in the URDF.
 
 ### .axis
 
@@ -356,6 +356,14 @@ name : string
 ```
 
 The name of the link.
+
+### .inertial
+
+```js
+inertial : { mass : number, origin : { xyz : number[], rpy : number[] }, inertia : { ixx, ixy, ixz, iyy, iyz, izz : number } }
+```
+
+The inertial properties of the link parsed from the `<inertial>` element. All fields default to zero if not specified in the URDF.
 
 ## URDFRobot
 

--- a/javascript/src/URDFClasses.d.ts
+++ b/javascript/src/URDFClasses.d.ts
@@ -19,9 +19,21 @@ export class URDFVisual extends URDFBase {
 
 }
 
+export interface URDFInertial {
+
+    mass: number;
+    origin: { xyz: number[], rpy: number[] };
+    inertia: {
+        ixx: number; ixy: number; ixz: number;
+        iyy: number; iyz: number; izz: number;
+    };
+
+}
+
 export class URDFLink extends URDFBase {
 
     isURDFLink: true;
+    inertial: URDFInertial;
 
 }
 
@@ -34,7 +46,7 @@ export class URDFJoint extends URDFBase {
     jointType: 'fixed' | 'continuous' | 'revolute' | 'planar' | 'prismatic' | 'floating';
     angle: number;
     jointValue: number[];
-    limit: { lower: number, upper: number }; // TODO: add more
+    limit: { lower: number, upper: number, effort: number, velocity: number };
     ignoreLimits: boolean;
     mimicJoints: URDFMimicJoint[];
 

--- a/javascript/src/URDFClasses.js
+++ b/javascript/src/URDFClasses.js
@@ -63,6 +63,8 @@ class URDFLink extends URDFBase {
         this.isURDFLink = true;
         this.type = 'URDFLink';
 
+        this.inertial = null;
+
     }
 
 }
@@ -122,7 +124,7 @@ class URDFJoint extends URDFBase {
         this.jointValue = null;
         this.jointType = 'fixed';
         this.axis = new Vector3(1, 0, 0);
-        this.limit = { lower: 0, upper: 0 };
+        this.limit = { lower: 0, upper: 0, effort: null, velocity: null };
         this.ignoreLimits = false;
 
         this.origPosition = null;
@@ -141,6 +143,8 @@ class URDFJoint extends URDFBase {
         this.axis = source.axis.clone();
         this.limit.lower = source.limit.lower;
         this.limit.upper = source.limit.upper;
+        this.limit.effort = source.limit.effort;
+        this.limit.velocity = source.limit.velocity;
         this.ignoreLimits = false;
 
         this.jointValue = [...source.jointValue];

--- a/javascript/src/URDFClasses.js
+++ b/javascript/src/URDFClasses.js
@@ -63,7 +63,28 @@ class URDFLink extends URDFBase {
         this.isURDFLink = true;
         this.type = 'URDFLink';
 
-        this.inertial = null;
+        this.inertial = {
+            mass: 0,
+            origin: { xyz: [0, 0, 0], rpy: [0, 0, 0] },
+            inertia: { ixx: 0, ixy: 0, ixz: 0, iyy: 0, iyz: 0, izz: 0 },
+        };
+
+    }
+
+    copy(source, recursive) {
+
+        super.copy(source, recursive);
+
+        this.inertial = {
+            mass: source.inertial.mass,
+            origin: {
+                xyz: [...source.inertial.origin.xyz],
+                rpy: [...source.inertial.origin.rpy],
+            },
+            inertia: { ...source.inertial.inertia },
+        };
+
+        return this;
 
     }
 
@@ -124,7 +145,7 @@ class URDFJoint extends URDFBase {
         this.jointValue = null;
         this.jointType = 'fixed';
         this.axis = new Vector3(1, 0, 0);
-        this.limit = { lower: 0, upper: 0, effort: null, velocity: null };
+        this.limit = { lower: 0, upper: 0, effort: 0, velocity: 0 };
         this.ignoreLimits = false;
 
         this.origPosition = null;

--- a/javascript/src/URDFLoader.js
+++ b/javascript/src/URDFLoader.js
@@ -37,6 +37,14 @@ function processTuple(val) {
 
 }
 
+// take a vector "x y z" and process it into
+// a THREE.Vector3
+function processVector(val) {
+
+    return new THREE.Vector3(...processTuple(val));
+
+}
+
 // applies a rotation a threejs object in URDF order
 function applyRotation(obj, rpy, additive = false) {
 
@@ -364,6 +372,8 @@ class URDFLoader {
 
                     obj.limit.lower = parseFloat(n.getAttribute('lower') || obj.limit.lower);
                     obj.limit.upper = parseFloat(n.getAttribute('upper') || obj.limit.upper);
+                    obj.limit.effort = parseFloat(n.getAttribute('effort') || obj.limit.effort);
+                    obj.limit.velocity = parseFloat(n.getAttribute('velocity') || obj.limit.velocity);
 
                 }
             });
@@ -402,6 +412,36 @@ class URDFLoader {
             target.name = link.getAttribute('name');
             target.urdfName = target.name;
             target.urdfNode = link;
+
+            // Extract the attributes
+            children.forEach(n => {
+
+                const type = n.nodeName.toLowerCase();
+                if (type === 'inertial') {
+                    const subNodes = [ ...n.children ];
+                    const origin = subNodes.find(sn => sn.nodeName.toLowerCase() === 'origin');
+                    const xyz = origin ? origin.getAttribute('xyz') : null;
+                    const rpy = origin ? origin.getAttribute('rpy') : null;
+                    const mass = subNodes.find(sn => sn.nodeName.toLowerCase() === 'mass');
+                    const inertia = subNodes.find(sn => sn.nodeName.toLowerCase() === 'inertia');
+                    target.inertial = origin || mass || inertia ? {
+                        origin: xyz || rpy ? {
+                            xyz: xyz ? processVector(xyz) : null,
+                            rpy: rpy ? processVector(rpy) : null,
+                        } : null,
+                        mass: mass ? parseFloat(mass.getAttribute('value') || 0) : null,
+                        inertia: inertia ? {
+                            ixx: parseFloat(inertia.getAttribute('ixx') || 0),
+                            ixy: parseFloat(inertia.getAttribute('ixy') || 0),
+                            ixz: parseFloat(inertia.getAttribute('ixz') || 0),
+                            iyy: parseFloat(inertia.getAttribute('iyy') || 0),
+                            iyz: parseFloat(inertia.getAttribute('iyz') || 0),
+                            izz: parseFloat(inertia.getAttribute('izz') || 0),
+                        } : null,
+                    } : null;
+
+                }
+            });
 
             if (parseVisual) {
 

--- a/javascript/src/URDFLoader.js
+++ b/javascript/src/URDFLoader.js
@@ -37,14 +37,6 @@ function processTuple(val) {
 
 }
 
-// take a vector "x y z" and process it into
-// a THREE.Vector3
-function processVector(val) {
-
-    return new THREE.Vector3(...processTuple(val));
-
-}
-
 // applies a rotation a threejs object in URDF order
 function applyRotation(obj, rpy, additive = false) {
 
@@ -413,35 +405,36 @@ class URDFLoader {
             target.urdfName = target.name;
             target.urdfNode = link;
 
-            // Extract the attributes
-            children.forEach(n => {
+            // Parse inertial properties
+            const inertialNode = children.find(n => n.nodeName.toLowerCase() === 'inertial');
+            if (inertialNode) {
 
-                const type = n.nodeName.toLowerCase();
-                if (type === 'inertial') {
-                    const subNodes = [ ...n.children ];
-                    const origin = subNodes.find(sn => sn.nodeName.toLowerCase() === 'origin');
-                    const xyz = origin ? origin.getAttribute('xyz') : null;
-                    const rpy = origin ? origin.getAttribute('rpy') : null;
-                    const mass = subNodes.find(sn => sn.nodeName.toLowerCase() === 'mass');
-                    const inertia = subNodes.find(sn => sn.nodeName.toLowerCase() === 'inertia');
-                    target.inertial = origin || mass || inertia ? {
-                        origin: xyz || rpy ? {
-                            xyz: xyz ? processVector(xyz) : null,
-                            rpy: rpy ? processVector(rpy) : null,
-                        } : null,
-                        mass: mass ? parseFloat(mass.getAttribute('value') || 0) : null,
-                        inertia: inertia ? {
-                            ixx: parseFloat(inertia.getAttribute('ixx') || 0),
-                            ixy: parseFloat(inertia.getAttribute('ixy') || 0),
-                            ixz: parseFloat(inertia.getAttribute('ixz') || 0),
-                            iyy: parseFloat(inertia.getAttribute('iyy') || 0),
-                            iyz: parseFloat(inertia.getAttribute('iyz') || 0),
-                            izz: parseFloat(inertia.getAttribute('izz') || 0),
-                        } : null,
-                    } : null;
+                [ ...inertialNode.children ].forEach(n => {
 
-                }
-            });
+                    const type = n.nodeName.toLowerCase();
+                    if (type === 'origin') {
+
+                        target.inertial.origin.xyz = processTuple(n.getAttribute('xyz'));
+                        target.inertial.origin.rpy = processTuple(n.getAttribute('rpy'));
+
+                    } else if (type === 'mass') {
+
+                        target.inertial.mass = parseFloat(n.getAttribute('value')) || 0;
+
+                    } else if (type === 'inertia') {
+
+                        target.inertial.inertia.ixx = parseFloat(n.getAttribute('ixx')) || 0;
+                        target.inertial.inertia.ixy = parseFloat(n.getAttribute('ixy')) || 0;
+                        target.inertial.inertia.ixz = parseFloat(n.getAttribute('ixz')) || 0;
+                        target.inertial.inertia.iyy = parseFloat(n.getAttribute('iyy')) || 0;
+                        target.inertial.inertia.iyz = parseFloat(n.getAttribute('iyz')) || 0;
+                        target.inertial.inertia.izz = parseFloat(n.getAttribute('izz')) || 0;
+
+                    }
+
+                });
+
+            }
 
             if (parseVisual) {
 

--- a/javascript/test/URDFRobot.test.js
+++ b/javascript/test/URDFRobot.test.js
@@ -1,5 +1,4 @@
 import { JSDOM } from 'jsdom';
-import { Vector3 } from 'three';
 import URDFLoader from '../src/URDFLoader.js';
 
 const jsdom = new JSDOM();
@@ -62,10 +61,10 @@ describe('URDFRobot', () => {
         expect(robot.joints.JOINT1.limit.upper).toEqual(3.14);
         expect(robot.joints.JOINT1.limit.velocity).toEqual(5.20);
 
-        expect(robot.joints.JOINT2.limit.effort).toEqual(null);
+        expect(robot.joints.JOINT2.limit.effort).toEqual(0);
         expect(robot.joints.JOINT2.limit.lower).toEqual(0);
         expect(robot.joints.JOINT2.limit.upper).toEqual(0);
-        expect(robot.joints.JOINT2.limit.velocity).toEqual(null);
+        expect(robot.joints.JOINT2.limit.velocity).toEqual(0);
     });
 
     it('should correctly parse joint inertial data.', () => {
@@ -94,8 +93,8 @@ describe('URDFRobot', () => {
             </robot>
         `);
 
-        expect(robot.links.LINK1.inertial.origin.rpy).toEqual(new Vector3(0, 0, -1.5707963267948966));
-        expect(robot.links.LINK1.inertial.origin.xyz).toEqual(new Vector3(0.14635000035763, 0, 0));
+        expect(robot.links.LINK1.inertial.origin.rpy).toEqual([0, 0, -1.5707963267948966]);
+        expect(robot.links.LINK1.inertial.origin.xyz).toEqual([0.14635000035763, 0, 0]);
         expect(robot.links.LINK1.inertial.mass).toEqual(2.5076);
         expect(robot.links.LINK1.inertial.inertia.ixx).toEqual(0.00443333156);
         expect(robot.links.LINK1.inertial.inertia.iyy).toEqual(0.00443333156);
@@ -104,7 +103,11 @@ describe('URDFRobot', () => {
         expect(robot.links.LINK1.inertial.inertia.ixz).toEqual(0);
         expect(robot.links.LINK1.inertial.inertia.iyz).toEqual(0);
 
-        expect(robot.links.LINK2.inertial).toEqual(null);
+        // LINK2 has no <inertial> tag — should still have default values
+        expect(robot.links.LINK2.inertial.mass).toEqual(0);
+        expect(robot.links.LINK2.inertial.origin.xyz).toEqual([0, 0, 0]);
+        expect(robot.links.LINK2.inertial.origin.rpy).toEqual([0, 0, 0]);
+        expect(robot.links.LINK2.inertial.inertia.ixx).toEqual(0);
     });
 
     it('should parse material colors and name.', () => {


### PR DESCRIPTION
Supersedes #299 by @dkozma -- this PR is based on their work with review feedback addressed.

## Changes

**Inertial parsing (`<link>`)**
- Parses `<inertial>` child elements: `mass`, `origin` (xyz + rpy), and `inertia` (ixx, ixy, ixz, iyy, iyz, izz)
- `inertial` is always present on `URDFLink` with URDF spec defaults (mass: 0, origin: identity, inertia: zeros), same pattern as `limit` on `URDFJoint`
- Uses `number[]` for origin xyz/rpy (consistent with `processTuple`)
- Added `copy()` to `URDFLink` for the new property
- Exported `URDFInertial` TypeScript interface

**Joint limits (`<joint>`)**
- Parses `effort` and `velocity` from `<limit>` elements
- Both default to 0 (not null)

**Other**
- Updated README documentation for `.inertial` on URDFLink and `.limit` on URDFJoint
- Updated tests (all 32 pass, 6 skipped, 1 todo -- all pre-existing)
- Dropped the `meshPath` addition from #299 (separate concern, `LoadingManager` is the right approach)

## Credit

Original work by @dkozma in #299. Review feedback from @gkjohnson addressed in [ferrolho@9d3c29a](https://github.com/ferrolho/urdf-loaders/commit/9d3c29a).