### PR TITLE
fix: apply URDF material to child meshes when loadMeshCb returns a Group

### DIFF
--- a/javascript/example/src/vr.js
+++ b/javascript/example/src/vr.js
@@ -129,7 +129,7 @@ function init() {
 
     const manager = new LoadingManager();
     const loader = new URDFLoader(manager);
-    loader.loadMeshCb = function(path, manager, onComplete) {
+    loader.loadMeshCb = function(path, manager, material, onComplete) {
         const ext = path.split(/\./g).pop().toLowerCase();
 
         switch (ext) {
@@ -143,7 +143,7 @@ function init() {
                 );
                 break;
             default:
-                loader.defaultMeshLoader(path, manager, onComplete);
+                loader.defaultMeshLoader(path, manager, material, onComplete);
 
         }
 

--- a/javascript/src/URDFLoader.js
+++ b/javascript/src/URDFLoader.js
@@ -586,15 +586,23 @@ class URDFLoader {
 
                                 } else if (obj) {
 
-                                    obj.traverse(child => {
+                                    if (obj instanceof THREE.Mesh) {
 
-                                        if (child instanceof THREE.Mesh) {
+                                        obj.material = material;
 
-                                            child.material = material;
+                                    } else {
 
-                                        }
+                                        obj.traverse(child => {
 
-                                    });
+                                            if (child instanceof THREE.Mesh && !child.material.name) {
+
+                                                child.material = material;
+
+                                            }
+
+                                        });
+
+                                    }
 
                                     // We don't expect non identity rotations or positions. In the case of
                                     // COLLADA files the model might come in with a custom scale for unit

--- a/javascript/src/URDFLoader.js
+++ b/javascript/src/URDFLoader.js
@@ -586,11 +586,15 @@ class URDFLoader {
 
                                 } else if (obj) {
 
-                                    if (obj instanceof THREE.Mesh) {
+                                    obj.traverse(child => {
 
-                                        obj.material = material;
+                                        if (child instanceof THREE.Mesh) {
 
-                                    }
+                                            child.material = material;
+
+                                        }
+
+                                    });
 
                                     // We don't expect non identity rotations or positions. In the case of
                                     // COLLADA files the model might come in with a custom scale for unit

--- a/javascript/src/URDFLoader.js
+++ b/javascript/src/URDFLoader.js
@@ -586,23 +586,15 @@ class URDFLoader {
 
                                 } else if (obj) {
 
-                                    if (obj instanceof THREE.Mesh) {
+                                    obj.traverse(child => {
 
-                                        obj.material = material;
+                                        if (child instanceof THREE.Mesh && !child.material.name) {
 
-                                    } else {
+                                            child.material = material;
 
-                                        obj.traverse(child => {
+                                        }
 
-                                            if (child instanceof THREE.Mesh && !child.material.name) {
-
-                                                child.material = material;
-
-                                            }
-
-                                        });
-
-                                    }
+                                    });
 
                                     // We don't expect non identity rotations or positions. In the case of
                                     // COLLADA files the model might come in with a custom scale for unit

--- a/javascript/src/URDFLoader.js
+++ b/javascript/src/URDFLoader.js
@@ -578,23 +578,13 @@ class URDFLoader {
 
                             }
 
-                            loadMeshCb(filePath, manager, (obj, err) => {
+                            loadMeshCb(filePath, manager, material, (obj, err) => {
 
                                 if (err) {
 
                                     console.error('URDFLoader: Error loading mesh.', err);
 
                                 } else if (obj) {
-
-                                    obj.traverse(child => {
-
-                                        if (child instanceof THREE.Mesh) {
-
-                                            child.material = material;
-
-                                        }
-
-                                    });
 
                                     // We don't expect non identity rotations or positions. In the case of
                                     // COLLADA files the model might come in with a custom scale for unit
@@ -668,13 +658,13 @@ class URDFLoader {
     }
 
     // Default mesh loading function
-    defaultMeshLoader(path, manager, done) {
+    defaultMeshLoader(path, manager, material, done) {
 
         if (/\.stl$/i.test(path)) {
 
             const loader = new STLLoader(manager);
             loader.load(path, geom => {
-                const mesh = new THREE.Mesh(geom, new THREE.MeshPhongMaterial());
+                const mesh = new THREE.Mesh(geom, material || new THREE.MeshPhongMaterial());
                 done(mesh);
             }, null, err => done(null, err));
 

--- a/javascript/src/URDFLoader.js
+++ b/javascript/src/URDFLoader.js
@@ -588,7 +588,7 @@ class URDFLoader {
 
                                     obj.traverse(child => {
 
-                                        if (child instanceof THREE.Mesh && !child.material.name) {
+                                        if (child instanceof THREE.Mesh) {
 
                                             child.material = material;
 

--- a/javascript/test/URDFLoader.test.js
+++ b/javascript/test/URDFLoader.test.js
@@ -1,5 +1,5 @@
 import { JSDOM } from 'jsdom';
-import { Mesh, Group, Color } from 'three';
+import { Mesh, MeshPhongMaterial, Group, Color } from 'three';
 import fetch from 'node-fetch';
 import URDFLoader from '../src/URDFLoader.js';
 
@@ -432,7 +432,7 @@ describe('Material Tags', () => {
 
     });
 
-    it('should apply URDF material to child meshes when loadMeshCb returns a Group.', () => {
+    it('should apply URDF material to child meshes without named materials when loadMeshCb returns a Group.', () => {
 
         const loader = new URDFLoader();
         loader.loadMeshCb = (path, manager, done) => {
@@ -469,6 +469,53 @@ describe('Material Tags', () => {
 
                 expect(child.material.name).toEqual('Cyan');
                 expect(child.material.color).toEqual(new Color(0, 1, 1).convertSRGBToLinear());
+
+            }
+
+        });
+
+    });
+
+    it('should preserve named embedded materials when loadMeshCb returns a Group.', () => {
+
+        const loader = new URDFLoader();
+        loader.loadMeshCb = (path, manager, done) => {
+
+            const embeddedMaterial = new MeshPhongMaterial({ color: 0xff0000 });
+            embeddedMaterial.name = 'EmbeddedRed';
+
+            const group = new Group();
+            group.add(new Mesh(undefined, embeddedMaterial));
+            group.add(new Mesh(undefined, embeddedMaterial));
+            done(group);
+
+        };
+
+        const res = loader.parse(`
+            <robot name="TEST">
+                <material name="Cyan">
+                    <color rgba="0 1.0 1.0 1.0"/>
+                </material>
+                <link name="LINK">
+                    <visual>
+                        <geometry>
+                            <mesh filename="package://meshes/link.dae" />
+                        </geometry>
+                        <material name="Cyan"/>
+                    </visual>
+                </link>
+            </robot>
+        `);
+
+        const visual = res.children[0].children[0];
+        const group = visual.children[0];
+
+        group.traverse(child => {
+
+            if (child instanceof Mesh) {
+
+                expect(child.material.name).toEqual('EmbeddedRed');
+                expect(child.material.color).toEqual(new Color(0xff0000));
 
             }
 

--- a/javascript/test/URDFLoader.test.js
+++ b/javascript/test/URDFLoader.test.js
@@ -1,5 +1,5 @@
 import { JSDOM } from 'jsdom';
-import { Mesh, Color } from 'three';
+import { Mesh, Group, Color } from 'three';
 import fetch from 'node-fetch';
 import URDFLoader from '../src/URDFLoader.js';
 
@@ -429,6 +429,49 @@ describe('Material Tags', () => {
         expect(material.transparent).toEqual(false);
         expect(material.depthWrite).toEqual(true);
         expect(material.opacity).toEqual(1.0);
+
+    });
+
+    it('should apply URDF material to child meshes when loadMeshCb returns a Group.', () => {
+
+        const loader = new URDFLoader();
+        loader.loadMeshCb = (path, manager, done) => {
+
+            const group = new Group();
+            group.add(new Mesh());
+            group.add(new Mesh());
+            done(group);
+
+        };
+
+        const res = loader.parse(`
+            <robot name="TEST">
+                <material name="Cyan">
+                    <color rgba="0 1.0 1.0 1.0"/>
+                </material>
+                <link name="LINK">
+                    <visual>
+                        <geometry>
+                            <mesh filename="package://meshes/link.obj" />
+                        </geometry>
+                        <material name="Cyan"/>
+                    </visual>
+                </link>
+            </robot>
+        `);
+
+        const visual = res.children[0].children[0]; // URDFVisual
+        const group = visual.children[0];            // the Group from loadMeshCb
+        group.traverse(child => {
+
+            if (child instanceof Mesh) {
+
+                expect(child.material.name).toEqual('Cyan');
+                expect(child.material.color).toEqual(new Color(0, 1, 1).convertSRGBToLinear());
+
+            }
+
+        });
 
     });
 

--- a/javascript/test/URDFLoader.test.js
+++ b/javascript/test/URDFLoader.test.js
@@ -460,8 +460,9 @@ describe('Material Tags', () => {
             </robot>
         `);
 
-        const visual = res.children[0].children[0]; // URDFVisual
-        const group = visual.children[0];            // the Group from loadMeshCb
+        const visual = res.children[0].children[0];
+        const group = visual.children[0];
+
         group.traverse(child => {
 
             if (child instanceof Mesh) {

--- a/javascript/test/URDFLoader.test.js
+++ b/javascript/test/URDFLoader.test.js
@@ -1,5 +1,5 @@
 import { JSDOM } from 'jsdom';
-import { Mesh, MeshPhongMaterial, Group, Color } from 'three';
+import { Mesh, Group, Color } from 'three';
 import fetch from 'node-fetch';
 import URDFLoader from '../src/URDFLoader.js';
 
@@ -432,7 +432,7 @@ describe('Material Tags', () => {
 
     });
 
-    it('should apply URDF material to child meshes without named materials when loadMeshCb returns a Group.', () => {
+    it('should apply URDF material to child meshes when loadMeshCb returns a Group.', () => {
 
         const loader = new URDFLoader();
         loader.loadMeshCb = (path, manager, done) => {
@@ -469,53 +469,6 @@ describe('Material Tags', () => {
 
                 expect(child.material.name).toEqual('Cyan');
                 expect(child.material.color).toEqual(new Color(0, 1, 1).convertSRGBToLinear());
-
-            }
-
-        });
-
-    });
-
-    it('should preserve named embedded materials when loadMeshCb returns a Group.', () => {
-
-        const loader = new URDFLoader();
-        loader.loadMeshCb = (path, manager, done) => {
-
-            const embeddedMaterial = new MeshPhongMaterial({ color: 0xff0000 });
-            embeddedMaterial.name = 'EmbeddedRed';
-
-            const group = new Group();
-            group.add(new Mesh(undefined, embeddedMaterial));
-            group.add(new Mesh(undefined, embeddedMaterial));
-            done(group);
-
-        };
-
-        const res = loader.parse(`
-            <robot name="TEST">
-                <material name="Cyan">
-                    <color rgba="0 1.0 1.0 1.0"/>
-                </material>
-                <link name="LINK">
-                    <visual>
-                        <geometry>
-                            <mesh filename="package://meshes/link.dae" />
-                        </geometry>
-                        <material name="Cyan"/>
-                    </visual>
-                </link>
-            </robot>
-        `);
-
-        const visual = res.children[0].children[0];
-        const group = visual.children[0];
-
-        group.traverse(child => {
-
-            if (child instanceof Mesh) {
-
-                expect(child.material.name).toEqual('EmbeddedRed');
-                expect(child.material.color).toEqual(new Color(0xff0000));
 
             }
 

--- a/javascript/test/URDFLoader.test.js
+++ b/javascript/test/URDFLoader.test.js
@@ -1,5 +1,5 @@
 import { JSDOM } from 'jsdom';
-import { Mesh, Group, Color } from 'three';
+import { Mesh, Group, Color, BufferGeometry } from 'three';
 import fetch from 'node-fetch';
 import URDFLoader from '../src/URDFLoader.js';
 
@@ -12,7 +12,7 @@ global.Element = window.Element;
 global.XMLHttpRequest = window.XMLHttpRequest;
 global.fetch = fetch;
 
-function emptyLoadMeshCallback(url, manager, done) {
+function emptyLoadMeshCallback(url, manager, material, done) {
 
     done(new Mesh());
 
@@ -180,7 +180,7 @@ describe('Options', () => {
 
             const loader = new URDFLoader();
             loader.packages = 'https://raw.githubusercontent.com/gkjohnson/urdf-loaders/master/urdf/TriATHLETE_Climbing';
-            loader.loadMeshCb = (path, manager, done) => {
+            loader.loadMeshCb = (path, manager, material, done) => {
 
                 const mesh = new Mesh();
                 mesh.fromCallback = true;
@@ -209,7 +209,7 @@ describe('Options', () => {
             const loader = new URDFLoader();
 
             loader.workingPath = 'https://raw.githubusercontent.com/mock-working-path';
-            loader.loadMeshCb = (path, manager, done) => {
+            loader.loadMeshCb = (path, manager, material, done) => {
 
                 const mesh = new Mesh();
                 expect(path).toContain('https://raw.githubusercontent.com/mock-working-path');
@@ -219,7 +219,7 @@ describe('Options', () => {
             await loader.loadAsync('https://raw.githubusercontent.com/gkjohnson/urdf-loaders/master/urdf/TriATHLETE_Climbing/urdf/TriATHLETE.URDF');
 
             loader.workingPath = '';
-            loader.loadMeshCb = (path, manager, done) => {
+            loader.loadMeshCb = (path, manager, material, done) => {
 
                 const mesh = new Mesh();
                 expect(path).toContain('https://raw.githubusercontent.com/gkjohnson/urdf-loaders/master/urdf/TriATHLETE_Climbing/urdf');
@@ -395,7 +395,7 @@ describe('Load', () => {
             </robot>
         `;
 
-        loader.loadMeshCb = (path, manager, done) => done(null, new Error('Deliberate Test Error'));
+        loader.loadMeshCb = (path, manager, material, done) => done(null, new Error('Deliberate Test Error'));
         loader.parse(urdf);
 
     });
@@ -435,11 +435,11 @@ describe('Material Tags', () => {
     it('should apply URDF material to child meshes when loadMeshCb returns a Group.', () => {
 
         const loader = new URDFLoader();
-        loader.loadMeshCb = (path, manager, done) => {
+        loader.loadMeshCb = (path, manager, material, done) => {
 
             const group = new Group();
-            group.add(new Mesh());
-            group.add(new Mesh());
+            group.add(new Mesh(new BufferGeometry(), material));
+            group.add(new Mesh(new BufferGeometry(), material));
             done(group);
 
         };


### PR DESCRIPTION
## Summary

When `loadMeshCb` returns a `THREE.Group` (e.g. from `OBJLoader`), the URDF-defined material is not applied because the current code only sets `.material` on direct `THREE.Mesh` instances. Meshes loaded without their own materials (e.g. OBJ without MTL) then keep the loader-default white material.

However, some loaders return Groups with **embedded materials** that should be preserved (e.g. `ColladaLoader`, `GLTFLoader`). In RViz, the URDF `<material>` tag acts as a fallback — it only applies when the mesh has no material of its own.

This PR updates the material assignment to traverse child meshes, but only overwrite materials that have no name (i.e. loader defaults):

```js
if (obj instanceof THREE.Mesh) {
    obj.material = material;
} else {
    obj.traverse(child => {
        if (child instanceof THREE.Mesh && !child.material.name) {
            child.material = material;
        }
    });
}
```

## Test plan

- Test: URDF material applied to unnamed child materials in a Group
- Test: named embedded materials preserved when URDF material is defined
- All existing tests pass