### PR TITLE
fix: add validation for robot node in URDF parsing

### DIFF
--- a/javascript/src/URDFLoader.js
+++ b/javascript/src/URDFLoader.js
@@ -215,7 +215,12 @@ class URDFLoader {
 
             }
 
-            const robotNode = children.filter(c => c.nodeName === 'robot').pop();
+            const robotNode = children.filter(c => c.nodeName.toLowerCase() === 'robot').pop();
+            if (!robotNode) {
+
+                throw new Error('URDFLoader: No <robot> node found in URDF.');
+
+            }
             return processRobot(robotNode);
 
         }

--- a/javascript/test/URDFLoader.test.js
+++ b/javascript/test/URDFLoader.test.js
@@ -642,3 +642,18 @@ describe('Parsing Mimic Tags', () => {
     });
 
 });
+
+describe('Parsing', () => {
+
+    it('should throw an error if <robot> node is missing', () => {
+
+        const loader = new URDFLoader();
+        expect(() => {
+
+            loader.parse('<not-a-robot></not-a-robot>');
+
+        }).toThrow('URDFLoader: No <robot> node found in URDF.');
+
+    });
+
+});


### PR DESCRIPTION
Added a check to verify that a <robot> node exists when parsing a URDF file. This prevents runtime errors when attempting to access properties on a non-existent element in malformed or empty files. A corresponding test case has been added to verify this behavior.