### PR TITLE
align typescript with the JSDocs

### DIFF
--- a/javascript/src/URDFLoader.d.ts
+++ b/javascript/src/URDFLoader.d.ts
@@ -1,12 +1,12 @@
-import { LoadingManager, Object3D } from 'three';
+import { LoadingManager, Material, Object3D } from 'three';
 import { URDFRobot } from './URDFClasses';
 
-interface MeshLoadDoneFunc {
+interface OnMeshLoadComplete {
     (mesh: Object3D, err?: Error): void;
 }
 
 interface MeshLoadFunc{
-    (url: string, manager: LoadingManager, onLoad: MeshLoadDoneFunc): void;
+    (url: string, manager: LoadingManager, material: Material, onLoad: OnMeshLoadComplete): void;
 }
 
 export default class URDFLoader {


### PR DESCRIPTION
Fixes https://github.com/gkjohnson/urdf-loaders/issues/343 aligning the TS definitions with the JSDocs and the behavior of the JS.

For ref the JS docs show
```
/**
 * Called when a mesh has finished loading.
 * @callback OnMeshLoadComplete
 * @param {Object3D} obj The loaded mesh object, or null if an error occurred
 * @param {Error} [err] Error if loading failed
 */

/**
 * Function for loading mesh files referenced by the URDF.
 * @callback MeshLoadFunc
 * @param {string} pathToModel The url to load the model from
 * @param {LoadingManager} manager The THREE.js LoadingManager used by the URDFLoader
 * @param {Material} material The material derived from the URDF `<material>` tag for this visual element, or a default material if none was specified
 * @param {OnMeshLoadComplete} onComplete Called with the mesh once the geometry has been loaded
 */
 ```